### PR TITLE
Add float macro for cutscenes

### DIFF
--- a/include/command_macros_base.h
+++ b/include/command_macros_base.h
@@ -16,6 +16,12 @@
 
 #define CMD_W(a) (a)
 
+#ifdef COMPILER_GCC
+#define CMD_F(a) (.f = a)
+#else
+#define CMD_F(a) (a)
+#endif
+
 #define CMD_PTR(a) (u32)(a)
 
 #endif

--- a/include/z64cutscene_commands.h
+++ b/include/z64cutscene_commands.h
@@ -33,7 +33,7 @@
  *   size = 0x10
  */
 #define CS_CAM_POS(continueFlag, roll, frame, viewAngle, xPos, yPos, zPos, unused) \
-    CMD_BBH(continueFlag, roll, frame), CMD_W(viewAngle), CMD_HH(xPos, yPos), CMD_HH(zPos, unused)
+    CMD_BBH(continueFlag, roll, frame), CMD_F(viewAngle), CMD_HH(xPos, yPos), CMD_HH(zPos, unused)
 
 /**
  * ARGS
@@ -55,7 +55,7 @@
  *   size = 0x10
  */
 #define CS_CAM_FOCUS_POINT(continueFlag, roll, frame, viewAngle, xPos, yPos, zPos, unused) \
-    CMD_BBH(continueFlag, roll, frame), CMD_W(viewAngle), CMD_HH(xPos, yPos), CMD_HH(zPos, unused)
+    CMD_BBH(continueFlag, roll, frame), CMD_F(viewAngle), CMD_HH(xPos, yPos), CMD_HH(zPos, unused)
 
 /**
  * ARGS
@@ -122,7 +122,7 @@
  *   size = 0x10
  */
 #define CS_CAM_POS_PLAYER(continueFlag, roll, frame, viewAngle, xPos, yPos, zPos, unused) \
-    CMD_BBH(continueFlag, roll, frame), CMD_W(viewAngle), CMD_HH(xPos, yPos), CMD_HH(zPos, unused)
+    CMD_BBH(continueFlag, roll, frame), CMD_F(viewAngle), CMD_HH(xPos, yPos), CMD_HH(zPos, unused)
 
 /**
  * ARGS
@@ -144,7 +144,7 @@
  *   size = 0x10
  */
 #define CS_CAM_FOCUS_POINT_PLAYER(continueFlag, roll, frame, viewAngle, xPos, yPos, zPos, unused) \
-    CMD_BBH(continueFlag, roll, frame), CMD_W(viewAngle), CMD_HH(xPos, yPos), CMD_HH(zPos, unused)
+    CMD_BBH(continueFlag, roll, frame), CMD_F(viewAngle), CMD_HH(xPos, yPos), CMD_HH(zPos, unused)
 
 /**
  * ARGS
@@ -167,7 +167,7 @@
  *   size = 0x10
  */
 #define CS_CMD_07(continueFlag, roll, frame, viewAngle, xPos, yPos, zPos, unused) \
-    CMD_BBH(continueFlag, roll, frame), CMD_W(viewAngle), CMD_HH(xPos, yPos), CMD_HH(zPos, unused)
+    CMD_BBH(continueFlag, roll, frame), CMD_F(viewAngle), CMD_HH(xPos, yPos), CMD_HH(zPos, unused)
 
 /**
  * ARGS
@@ -190,7 +190,7 @@
  *   size = 0x10
  */
 #define CS_CMD_08(continueFlag, roll, frame, viewAngle, xPos, yPos, zPos, unused) \
-    CMD_BBH(continueFlag, roll, frame), CMD_W(viewAngle), CMD_HH(xPos, yPos), CMD_HH(zPos, unused)
+    CMD_BBH(continueFlag, roll, frame), CMD_F(viewAngle), CMD_HH(xPos, yPos), CMD_HH(zPos, unused)
 
 /**
  * ARGS
@@ -257,7 +257,7 @@
     CMD_HH(npcAction, startFrame), CMD_HH(endFrame, rotX), CMD_HH(rotY, rotZ), \
     CMD_W(startX), CMD_W(startY), CMD_W(startZ), \
     CMD_W(endX), CMD_W(endY), CMD_W(endZ), \
-    CMD_W(normX), CMD_W(normY), CMD_W(normZ)
+    CMD_F(normX), CMD_F(normY), CMD_F(normZ)
 
 /**
  * ARGS


### PR DESCRIPTION
Cutscenes macros should now use designated initializers for floats when building with GCC